### PR TITLE
Add naive SSR implementation

### DIFF
--- a/app/lib/supabase.tsx
+++ b/app/lib/supabase.tsx
@@ -2,15 +2,31 @@ import React from "react";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { Auth } from "@supabase/ui";
 
+let clientSingleton: SupabaseClient;
+
+export function createSupabaseClient() {
+  if (clientSingleton) {
+    return clientSingleton;
+  }
+
+  const client = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+
+  if (typeof window !== "undefined") {
+    clientSingleton = client;
+  }
+  return client;
+}
+
 const SupabaseClientContext = React.createContext<SupabaseClient | null>(null);
 
-export function SupabaseProvider(props: { children: React.ReactNode }) {
-  const [client] = React.useState(() =>
-    createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    )
-  );
+export function SupabaseProvider(props: {
+  children: React.ReactNode;
+  client: SupabaseClient;
+}) {
+  const { client } = props;
 
   return (
     <SupabaseClientContext.Provider value={client}>

--- a/app/lib/urql.tsx
+++ b/app/lib/urql.tsx
@@ -1,30 +1,26 @@
-import React from "react";
-import { createClient, Provider } from "urql";
-import { useSupabaseClient } from "./supabase";
+import { NextUrqlClientConfig } from "next-urql";
+import { createSupabaseClient } from "./supabase";
 
-export function UrqlProvider(props: { children: React.ReactNode }) {
-  const supabaseClient = useSupabaseClient();
+export function getUrqlConfig(): NextUrqlClientConfig {
+  return (_ssrExchange, ctx) => {
+    const supabaseClient = createSupabaseClient();
 
-  function getHeaders(): Record<string, string> {
-    const headers: Record<string, string> = {
-      apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    };
-    const authorization = supabaseClient.auth.session()?.access_token;
+    function getHeaders(): Record<string, string> {
+      const headers: Record<string, string> = {
+        apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      };
+      const authorization = supabaseClient.auth.session()?.access_token;
 
-    if (authorization) {
-      headers["authorization"] = `Bearer ${authorization}`;
+      if (authorization) {
+        headers["authorization"] = `Bearer ${authorization}`;
+      }
+
+      return headers;
     }
 
-    return headers;
-  }
-
-  const [client] = React.useState(function createUrqlClient() {
-    return createClient({
+    return {
       url: `${process.env.NEXT_PUBLIC_SUPABASE_URL!}/graphql/v1`,
-      fetchOptions: function createFetchOptions() {
-        return { headers: getHeaders() };
-      },
-    });
-  });
-  return <Provider value={client}>{props.children}</Provider>;
+      fetchOptions: { headers: getHeaders() },
+    };
+  };
 }

--- a/app/lib/urql.tsx
+++ b/app/lib/urql.tsx
@@ -1,8 +1,8 @@
-import { NextUrqlClientConfig } from "next-urql";
+import { withUrqlClient } from "next-urql";
 import { createSupabaseClient } from "./supabase";
 
-export function getUrqlConfig(): NextUrqlClientConfig {
-  return (_ssrExchange, ctx) => {
+export const withConfiguredUrql = withUrqlClient(
+  (_ssrExchange, ctx) => {
     const supabaseClient = createSupabaseClient();
 
     function getHeaders(): Record<string, string> {
@@ -22,5 +22,6 @@ export function getUrqlConfig(): NextUrqlClientConfig {
       url: `${process.env.NEXT_PUBLIC_SUPABASE_URL!}/graphql/v1`,
       fetchOptions: { headers: getHeaders() },
     };
-  };
-}
+  },
+  { ssr: true }
+);

--- a/app/package.json
+++ b/app/package.json
@@ -14,14 +14,16 @@
     "@supabase/supabase-js": "1.31.2",
     "@supabase/ui": "0.36.4",
     "autoprefixer": "10.4.4",
-    "graphql": "16.3.0",
+    "graphql": "^16.3.0",
     "javascript-time-ago": "2.3.13",
     "next": "12.1.0",
+    "next-urql": "^3.3.2",
     "postcss": "8.4.12",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-is": "^18.0.0",
     "tailwindcss": "3.0.23",
-    "urql": "2.2.0"
+    "urql": "^2.2.0"
   },
   "devDependencies": {
     "@types/javascript-time-ago": "2.0.3",

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,16 +1,21 @@
-import { AuthChangeEvent } from "@supabase/supabase-js";
-import { withUrqlClient, WithUrqlProps } from "next-urql";
+import { WithUrqlProps } from "next-urql";
 import type { AppProps } from "next/app";
 import { FC, useEffect, useState } from "react";
 import { Footer } from "../lib/footer";
 import { Navigation } from "../lib/navigation";
 import { createSupabaseClient, SupabaseProvider } from "../lib/supabase";
-import { getUrqlConfig } from "../lib/urql";
 import "../styles/globals.css";
 
-const MyApp: FC<AppProps & WithUrqlProps> = (props) => {
-  const { Component, pageProps, resetUrqlClient } = props;
+type PagePropsWithMaybeUrql = WithUrqlProps | Record<any, any>;
+type MyAppProps = Omit<AppProps<PagePropsWithMaybeUrql>, "pageProps"> & {
+  pageProps: PagePropsWithMaybeUrql;
+};
+
+const MyApp: FC<MyAppProps> = (props) => {
+  const { Component, pageProps } = props;
   const [client] = useState(createSupabaseClient);
+
+  const resetUrqlClient = pageProps.resetUrqlClient;
 
   useEffect(() => {
     if (!resetUrqlClient) return;
@@ -33,4 +38,4 @@ const MyApp: FC<AppProps & WithUrqlProps> = (props) => {
   );
 };
 
-export default withUrqlClient(getUrqlConfig(), { ssr: true })(MyApp);
+export default MyApp;

--- a/app/pages/account.tsx
+++ b/app/pages/account.tsx
@@ -8,6 +8,7 @@ import { DocumentType, gql } from "../gql";
 import { Container } from "../lib/container";
 import { Loading } from "../lib/loading";
 import { MainSection } from "../lib/main-section";
+import { withConfiguredUrql } from "../lib/urql";
 
 const UserProfileQuery = gql(/* GraphQL */ `
   query UserProfileQuery($profileId: UUID!) {
@@ -172,4 +173,4 @@ function AccountForm(props: { profile: DocumentType<typeof ProfileFragment> }) {
   );
 }
 
-export default Account;
+export default withConfiguredUrql(Account);

--- a/app/pages/comments.tsx
+++ b/app/pages/comments.tsx
@@ -9,6 +9,7 @@ import { CommentItem } from "../lib/comment-item";
 import { Container } from "../lib/container";
 import { Loading } from "../lib/loading";
 import { MainSection } from "../lib/main-section";
+import { withConfiguredUrql } from "../lib/urql";
 import { usePaginatedQuery } from "../lib/use-paginated-query";
 
 const CommentsRouteQuery = gql(/* GraphQL */ `
@@ -93,4 +94,4 @@ const Comments: NextPage = () => {
   );
 };
 
-export default Comments;
+export default withConfiguredUrql(Comments);

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -8,6 +8,7 @@ import { FeedItem } from "../lib/feed-item";
 import { Loading } from "../lib/loading";
 import { MainSection } from "../lib/main-section";
 import { noopUUID } from "../lib/noop-uuid";
+import { withConfiguredUrql } from "../lib/urql";
 import { usePaginatedQuery } from "../lib/use-paginated-query";
 
 const IndexRouteQuery = gql(/* GraphQL */ `
@@ -93,4 +94,4 @@ const Home: NextPage = () => {
   );
 };
 
-export default Home;
+export default withConfiguredUrql(Home);

--- a/app/pages/item/[postId].tsx
+++ b/app/pages/item/[postId].tsx
@@ -11,6 +11,7 @@ import { FeedItem } from "../../lib/feed-item";
 import { Loading } from "../../lib/loading";
 import { MainSection } from "../../lib/main-section";
 import { noopUUID } from "../../lib/noop-uuid";
+import { withConfiguredUrql } from "../../lib/urql";
 
 const ItemRouteQuery = gql(/* GraphQL */ `
   query ItemRouteQuery($postId: BigInt!, $profileId: UUID!) {
@@ -135,4 +136,4 @@ const Item: NextPage = () => {
   );
 };
 
-export default Item;
+export default withConfiguredUrql(Item);

--- a/app/pages/newest.tsx
+++ b/app/pages/newest.tsx
@@ -8,6 +8,7 @@ import { FeedItem } from "../lib/feed-item";
 import { Loading } from "../lib/loading";
 import { MainSection } from "../lib/main-section";
 import { noopUUID } from "../lib/noop-uuid";
+import { withConfiguredUrql } from "../lib/urql";
 import { usePaginatedQuery } from "../lib/use-paginated-query";
 
 const NewestRouteQuery = gql(/* GraphQL */ `
@@ -93,4 +94,4 @@ const Newest: NextPage = () => {
   );
 };
 
-export default Newest;
+export default withConfiguredUrql(Newest);

--- a/app/pages/profile/[profileId].tsx
+++ b/app/pages/profile/[profileId].tsx
@@ -8,6 +8,7 @@ import { Container } from "../../lib/container";
 import { FeedItem } from "../../lib/feed-item";
 import { Loading } from "../../lib/loading";
 import { MainSection } from "../../lib/main-section";
+import { withConfiguredUrql } from "../../lib/urql";
 
 const ProfileRouteQuery = gql(/* GraphQL */ `
   query ProfileRouteQuery($profileId: UUID!) {
@@ -130,4 +131,4 @@ const Profile: NextPage = () => {
   );
 };
 
-export default Profile;
+export default withConfiguredUrql(Profile);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,7 +2878,7 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.6.3.tgz#32321594a7b744755df992f24afccc84143b4b7d"
   integrity sha512-ZolWOi6bzI35ovGROCZROB9nDbwZiJdIsaPdzW/jkICCGNb3qL/33IONY/yQiBa+Je2uA11HfY4Uxse4+/ePYA==
 
-graphql@16.3.0:
+graphql@16.3.0, graphql@^16.3.0:
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
   integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
@@ -3812,6 +3812,13 @@ next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
+next-urql@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/next-urql/-/next-urql-3.3.2.tgz#8be8e37f48726c55cb1c3eecb8c2003bdc319f2e"
+  integrity sha512-oXQHCFU0R3pIwXWtDqZDYOjKcD7SlNP7aove9YuukgKuItdtIR9CRUgo3qMOD5dSQ3wBBGfQ8zR6XtzqV5WiGg==
+  dependencies:
+    react-ssr-prepass "^1.4.0"
+
 next@12.1.0:
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/next/-/next-12.1.0.tgz#c33d753b644be92fc58e06e5a214f143da61dd5d"
@@ -4341,6 +4348,16 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.0.0.tgz#026f6c4a27dbe33bf4a35655b9e1327c4e55e3f5"
+  integrity sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==
+
+react-ssr-prepass@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.5.0.tgz#bc4ca7fcb52365e6aea11cc254a3d1bdcbd030c5"
+  integrity sha512-yFNHrlVEReVYKsLI5lF05tZoHveA5pGzjFbFJY/3pOqqjGOmMmqx83N4hIjN2n6E1AOa+eQEUxs3CgRnPmT0RQ==
 
 react@17.0.2:
   version "17.0.2"
@@ -5151,7 +5168,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-urql@2.2.0:
+urql@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/urql/-/urql-2.2.0.tgz#5eade2813f5b61497086a5038ecc7c6e7cbd7153"
   integrity sha512-36wnWqDrpXqhwT5r2/qRSZXhb7Y4sXA0nLlYEd3uLgvfIdOA8kUaPdfTujzfrvfCcfiVVFxhzqVAhc8r17NMwQ==


### PR DESCRIPTION
Hey, it bothered me a bit that I couldn't navigate without clientside JS enabled so this makes the example useable enough for those cases.

It's opting out pages with a query requirement of the automatic static optimization, which is slower, but I didn't want to assume too much and build the static generation for this as well. It's doable, but it's messy

Feel free to annotate changes, I've used arrow functions at most spots because I don't know how to write Typescript without them so if these are remarked then I'd appreciate a suggestion since I don't know where the correct positioning is.

